### PR TITLE
fix(article): only update links for relative images

### DIFF
--- a/src/article.spec.ts
+++ b/src/article.spec.ts
@@ -39,5 +39,9 @@ describe(`Article`, () => {
         `Image 3: ![alt text 3](https://raw.githubusercontent.com/${repository.username}/${repository.name}/master/test/image-3.png)`,
       );
     });
+
+    it(`should NOT rewrite absolute images URLs to match the raw file on github`, () => {
+      expect(articleRead).toContain(`Absolute image: ![alt text](http://google.com/absolute-image.png)`);
+    });
   });
 });

--- a/src/article.ts
+++ b/src/article.ts
@@ -7,7 +7,7 @@ interface ArticleFrontMatter {
   title: string;
 }
 
-const imagesRe: RegExp = /\!\[.*\]\(.*\)/g;
+const imagesRe: RegExp = /\!\[.*\]\(\.\/.*\)/g;
 const imageRe: RegExp = /\!\[(.*)\]\(([^ \)]*)(?: '(.*)')?\)/;
 
 const excludeArticleFromPath = (path: string): string => path.replace(/\/[^\/]+\.md$/, '');

--- a/test/article.md
+++ b/test/article.md
@@ -9,6 +9,8 @@ canonical_url:
 
 # This is my awesome article!
 
+## Relative images
+
 Hey, some text!
 
 Image 1: ![alt text 1](./image-1.png 'Title image 1')
@@ -16,3 +18,7 @@ Image 1: ![alt text 1](./image-1.png 'Title image 1')
 Image 2: ![alt text 2](./image-2.png 'Title image 2')
 
 Image 3: ![alt text 3](./image-3.png)
+
+## Absolute images
+
+Absolute image: ![alt text](http://google.com/absolute-image.png)


### PR DESCRIPTION
I can't get the tests running locally but I hope this should work.

Should close #10 