### PR TITLE
handle 422 error after changes to dev.to api

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "node": ">=6.0.0"
   },
   "scripts": {
-    "copy-index": "cp ./src/index.js ./bin",
+    "copy-index": "cp ./src/index.js ./bin && chmod +x ./bin/index.js",
     "prettier:base": "yarn run prettier \"./{src,test}/**/*.ts\" \"./**/*.{yml,md,json}\"",
     "prettier:fix": "yarn run prettier:base --write",
     "lint": "tslint  --project tsconfig.json -t codeFrame 'src/**/*.ts' 'test/**/*.ts'",

--- a/src/article.ts
+++ b/src/article.ts
@@ -79,7 +79,7 @@ export class Article {
   }
 
   public async publishArticle(): Promise<ArticlePublishedStatus> {
-    const articleFromDisk = this.readArticleOnDisk();
+    const articleFromDisk: string = this.readArticleOnDisk();
     let frontMatter: ArticleFrontMatter;
     let body_markdown;
     try {

--- a/src/article.ts
+++ b/src/article.ts
@@ -81,7 +81,7 @@ export class Article {
   public async publishArticle(): Promise<ArticlePublishedStatus> {
     const articleFromDisk: string = this.readArticleOnDisk();
     let frontMatter: ArticleFrontMatter;
-    let body_markdown;
+    let body_markdown: string | undefined;
     try {
       const extraction = this.extractDataFromFrontMatter(articleFromDisk);
       frontMatter = extraction.attributes;


### PR DESCRIPTION
closes #35 

The dev.to api has both changed, and has an invalid example.

It has changed to require the `body_markdown` to be nested with an `article` key, and it also will not accept front matter inside the `body_markdown`, requiring these attributes instead to be passed in as json, under the `article` key.  This patch handles these changes.  The error to their documentation has been reported here: https://github.com/forem/forem/issues/12712

`chmod +x` was added to the `package.json` file to allow debugging by running the file directly.