### PR TITLE
fix: update PUT body to match forem's API

### DIFF
--- a/src/article.ts
+++ b/src/article.ts
@@ -80,13 +80,13 @@ export class Article {
 
   public async publishArticle(): Promise<ArticlePublishedStatus> {
     const body: ArticleApi = {
-      body_markdown: this.readArticleOnDisk(),
+      article: { body_markdown: this.readArticleOnDisk() },
     };
 
     let frontMatter: ArticleFrontMatter;
 
     try {
-      frontMatter = this.extractDataFromFrontMatter(body.body_markdown);
+      frontMatter = this.extractDataFromFrontMatter(body.article.body_markdown);
     } catch {
       return Promise.resolve({
         articleId: this.articleConfig.id,
@@ -113,7 +113,7 @@ export class Article {
       };
     }
 
-    if (remoteArticleBodyMarkdown && remoteArticleBodyMarkdown.trim() === body.body_markdown.trim()) {
+    if (remoteArticleBodyMarkdown && remoteArticleBodyMarkdown.trim() === body.article.body_markdown.trim()) {
       return {
         articleId: this.articleConfig.id,
         updateStatus: UpdateStatus.ALREADY_UP_TO_DATE as UpdateStatus.ALREADY_UP_TO_DATE,

--- a/src/dev-to-git.interface.ts
+++ b/src/dev-to-git.interface.ts
@@ -13,8 +13,11 @@ export interface ArticleConfig extends ArticleConfigFile {
 }
 
 // https://dev.to/api#available-json-parameters
+// new Dev.to update parameters https://docs.forem.com/api/#operation/updateArticle
 export interface ArticleApi {
-  body_markdown: string;
+  article: {
+    body_markdown: string;
+  };
 }
 
 export interface ArticleApiResponse {


### PR DESCRIPTION
The PUT API for updating an article expects an `article` property
on the body that that `body_markdown` is a part of. This should be
a pretty simple API change along with the interface update.

As a side note, I was not able to get tests running locally,
but I'll adjust accordingly as I need to from the CI  results.

closes #35